### PR TITLE
Enable Dynamic shader resolution

### DIFF
--- a/imaging_sonar_simulation.orogen
+++ b/imaging_sonar_simulation.orogen
@@ -65,5 +65,5 @@ task_context "MultibeamSonarTask" do
     # Number of Beams
     property("beam_count", "int", 256)
 
-    periodic 0.1
+    port_driven
 end

--- a/imaging_sonar_simulation.orogen
+++ b/imaging_sonar_simulation.orogen
@@ -63,7 +63,7 @@ task_context "MultibeamSonarTask" do
     subclasses "imaging_sonar_simulation::Task"
 
     # Number of Beams
-    property("beam_count", "int", 256)
+    property("beam_count", "int", 256).dynamic
 
     port_driven
 end

--- a/tasks/MultibeamSonarTask.cpp
+++ b/tasks/MultibeamSonarTask.cpp
@@ -45,7 +45,7 @@ bool MultibeamSonarTask::startHook() {
 
     // generate shader world
     uint width = 3328;
-    Task::initShader(width, false);
+    Task::setupShader(width, false);
 
     return true;
 }

--- a/tasks/MultibeamSonarTask.cpp
+++ b/tasks/MultibeamSonarTask.cpp
@@ -102,3 +102,12 @@ bool MultibeamSonarTask::setBin_count(int value) {
     Task::setupShader(width, false);
     return (imaging_sonar_simulation::TaskBase::setBin_count(value));
 }
+
+bool MultibeamSonarTask::setBeam_count(int value) {
+    if (value < 64 || value > 512) {
+        RTT::log(RTT::Error) << "The number of beams must be between 64 and 512." << RTT::endlog();
+        return false;
+    }
+    sonar_sim.beam_count = value;
+    return (imaging_sonar_simulation::TaskBase::setBin_count(value));
+}

--- a/tasks/MultibeamSonarTask.cpp
+++ b/tasks/MultibeamSonarTask.cpp
@@ -44,7 +44,7 @@ bool MultibeamSonarTask::startHook() {
 		return false;
 
     // generate shader world
-    uint width = 3328;
+    uint width = sonar_sim.bin_count * 5.12;  // 5.12 pixels are needed for each bin
     Task::setupShader(width, false);
 
     return true;
@@ -90,4 +90,15 @@ void MultibeamSonarTask::stopHook() {
 
 void MultibeamSonarTask::cleanupHook() {
 	MultibeamSonarTaskBase::cleanupHook();
+}
+
+bool MultibeamSonarTask::setBin_count(int value) {
+    if (value <= 0) {
+        RTT::log(RTT::Error) << "The number of bins must be positive." << RTT::endlog();
+        return false;
+    }
+    sonar_sim.bin_count = value;
+    float width = sonar_sim.bin_count * 5.12;  // 5.12 pixels are needed for each bin
+    Task::setupShader(width, false);
+    return (imaging_sonar_simulation::TaskBase::setBin_count(value));
 }

--- a/tasks/MultibeamSonarTask.hpp
+++ b/tasks/MultibeamSonarTask.hpp
@@ -25,6 +25,12 @@ namespace imaging_sonar_simulation{
     {
 	friend class MultibeamSonarTaskBase;
     protected:
+        /** Dynamically update the number of bins
+        *
+        * @param value: desired number of bins
+        * @return if the process is finished successfully
+        */
+        virtual bool setBin_count(int value);
 
     public:
         /** TaskContext constructor for MultibeamSonarTask

--- a/tasks/MultibeamSonarTask.hpp
+++ b/tasks/MultibeamSonarTask.hpp
@@ -32,6 +32,13 @@ namespace imaging_sonar_simulation{
         */
         virtual bool setBin_count(int value);
 
+        /** Dynamically update the number of beams
+        *
+        * @param value: desired number of bins
+        * @return if the process is finished successfully
+        */
+        virtual bool setBeam_count(int value);
+
     public:
         /** TaskContext constructor for MultibeamSonarTask
          * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
@@ -41,7 +48,7 @@ namespace imaging_sonar_simulation{
 
         /** TaskContext constructor for MultibeamSonarTask
          * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices.
-         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task. 
+         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task.
          *
          */
         MultibeamSonarTask(std::string const& name, RTT::ExecutionEngine* engine);

--- a/tasks/ScanningSonarTask.cpp
+++ b/tasks/ScanningSonarTask.cpp
@@ -56,7 +56,7 @@ bool ScanningSonarTask::startHook() {
 		return false;
 
     // generate shader world
-    int height = 1024;
+    int height = sonar_sim.bin_count * 5.12;    // 5.12 pixels are needed for each bin
     Task::setupShader(height, true);
 
     current_bearing = base::Angle::fromRad(0.0);
@@ -165,4 +165,16 @@ bool ScanningSonarTask::setMotor_step(::base::Angle const & value) {
 bool ScanningSonarTask::setContinuous(bool value) {
     continuous = value;
     return (imaging_sonar_simulation::ScanningSonarTaskBase::setContinuous(value));
+}
+
+bool ScanningSonarTask::setBin_count(int value) {
+    if (value <= 0) {
+        RTT::log(RTT::Error) << "The number of bins must be positive." << RTT::endlog();
+        return false;
+    }
+
+    sonar_sim.bin_count = value;
+    float height = sonar_sim.bin_count * 5.12;  // 5.12 pixels are needed for each bin
+    Task::setupShader(height, true);
+    return (imaging_sonar_simulation::TaskBase::setBin_count(value));
 }

--- a/tasks/ScanningSonarTask.cpp
+++ b/tasks/ScanningSonarTask.cpp
@@ -57,7 +57,7 @@ bool ScanningSonarTask::startHook() {
 
     // generate shader world
     int height = 1024;
-    Task::initShader(height, true);
+    Task::setupShader(height, true);
 
     current_bearing = base::Angle::fromRad(0.0);
     invert = false;

--- a/tasks/ScanningSonarTask.hpp
+++ b/tasks/ScanningSonarTask.hpp
@@ -82,6 +82,13 @@ protected:
     */
     virtual bool setContinuous(bool value);
 
+    /** Dynamically update the number of bins
+    *
+    * @param value: desired number of bins
+    * @return if the process is finished successfully
+    */
+    virtual bool setBin_count(int value);
+
 public:
 	/** TaskContext constructor for ScanningSonarTask
 	 * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -150,13 +150,3 @@ bool Task::setGain(double value) {
     gain = value;
     return (imaging_sonar_simulation::TaskBase::setGain(value));
 }
-
-bool Task::setBin_count(int value) {
-    if (value <= 0) {
-        RTT::log(RTT::Error) << "The number of bins must be positive." << RTT::endlog();
-        return false;
-    }
-
-    sonar_sim.bin_count = value;
-    return (imaging_sonar_simulation::TaskBase::setBin_count(value));
-}

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -126,6 +126,7 @@ void Task::processShader(osg::ref_ptr<osg::Image>& osg_image, std::vector<float>
     cv_image.convertTo(cv_image, CV_8UC3, 255);
     cv::flip(cv_image, cv_image, 0);
     frame_helper::FrameHelper::copyMatToFrame(cv_image, *frame.get());
+    frame->time = base::Time::now();
     _shader_viewer.write(RTT::extras::ReadOnlyPointer<Frame>(frame.release()));
 }
 

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -73,7 +73,7 @@ void Task::cleanupHook() {
 	TaskBase::cleanupHook();
 }
 
-void Task::initShader(uint value, bool isHeight) {
+void Task::setupShader(uint value, bool isHeight) {
     double const half_fovx = sonar_sim.beam_width.getRad() / 2;
     double const half_fovy = sonar_sim.beam_height.getRad() / 2;
 

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -81,13 +81,6 @@ namespace imaging_sonar_simulation{
         */
         virtual bool setGain(double value);
 
-        /** Dynamically update the number of bins
-        *
-        * @param value: desired number of bins
-        * @return if the process is finished successfully
-        */
-        virtual bool setBin_count(int value);
-
     public:
         /** TaskContext constructor for Task
          * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -52,7 +52,7 @@ namespace imaging_sonar_simulation{
         *  @param isHeight: if true, the value is related with image height
         *                   otherwise, the vale is related with image width
         */
-        void initShader(uint value, bool isHeight = true);
+        void setupShader(uint value, bool isHeight = true);
 
         /**
         *  Update sonar pose according to auv pose.


### PR DESCRIPTION
* shader resolution now is dependent of number of bins
* number of beams as dynamic property
* multibeam sonar as data-driven task
* rename shader initialization method
* correct time in output frame